### PR TITLE
Use "g_per_L" for rate_g_per_ha calculation when only dosage is given…

### DIFF
--- a/R/use-rates.R
+++ b/R/use-rates.R
@@ -120,8 +120,10 @@ application_rate_g_per_ha <- function(product_uses,
       units_de == "ml/10m\u00B2" ~ (rate/1000) * (g_per_L) * 1000,
       units_de == "ml/ha" ~ (rate/1000) * (g_per_L),
       units_de == "ml/a" ~ (rate/1000) * (g_per_L) * 100,
-      is.na(units_de) ~ ref_volume * 1000 * # 1 L has a weight of ca. 1000 g
-        dosage/100 * percent/100,
+      is.na(units_de) & !is.na(g_per_L) ~ ref_volume * 1000 * # 1 L has a weight of ca. 1000 g
+        dosage/100 * g_per_L/100, # g_per_L present -> liquid
+      is.na(units_de) & is.na(g_per_L) ~ ref_volume * 1000 * # 1 L has a weight of ca. 1000 g
+        dosage/100 * percent/100, # only percent present -> solids
       .default = NA))
   ret <- bind_cols(product_uses, active_rates["rate_g_per_ha"])
   return(ret)

--- a/R/use-rates.R
+++ b/R/use-rates.R
@@ -120,9 +120,10 @@ application_rate_g_per_ha <- function(product_uses,
       units_de == "ml/10m\u00B2" ~ (rate/1000) * (g_per_L) * 1000,
       units_de == "ml/ha" ~ (rate/1000) * (g_per_L),
       units_de == "ml/a" ~ (rate/1000) * (g_per_L) * 100,
-      is.na(units_de) & !is.na(g_per_L) ~ ref_volume * 1000 * # g_per_L available -> liquid
-        dosage/100 * g_per_L/100, # dosage assumed to be v/v
-      is.na(units_de) & is.na(g_per_L) ~ ref_volume * 1000 * # only percent available -> solid
+      is.na(units_de) & !is.na(g_per_L) ~ # g_per_L available -> liquid
+        ref_volume * dosage/100 * g_per_L, # dosage assumed to be v/v
+      is.na(units_de) & is.na(g_per_L) ~ # only percent available -> solid
+        ref_volume * 1000 * # 1 L spraying solution equivalent to 1000 g
         dosage/100 * percent/100, # dosage assumed to be w/w
       .default = NA))
   ret <- bind_cols(product_uses, active_rates["rate_g_per_ha"])

--- a/R/use-rates.R
+++ b/R/use-rates.R
@@ -120,10 +120,10 @@ application_rate_g_per_ha <- function(product_uses,
       units_de == "ml/10m\u00B2" ~ (rate/1000) * (g_per_L) * 1000,
       units_de == "ml/ha" ~ (rate/1000) * (g_per_L),
       units_de == "ml/a" ~ (rate/1000) * (g_per_L) * 100,
-      is.na(units_de) & !is.na(g_per_L) ~ ref_volume * 1000 * # 1 L has a weight of ca. 1000 g
-        dosage/100 * g_per_L/100, # g_per_L present -> liquid
-      is.na(units_de) & is.na(g_per_L) ~ ref_volume * 1000 * # 1 L has a weight of ca. 1000 g
-        dosage/100 * percent/100, # only percent present -> solids
+      is.na(units_de) & !is.na(g_per_L) ~ ref_volume * 1000 * # g_per_L available -> liquid
+        dosage/100 * g_per_L/100, # dosage assumed to be v/v
+      is.na(units_de) & is.na(g_per_L) ~ ref_volume * 1000 * # only percent available -> solid
+        dosage/100 * percent/100, # dosage assumed to be w/w
       .default = NA))
   ret <- bind_cols(product_uses, active_rates["rate_g_per_ha"])
   return(ret)


### PR DESCRIPTION
… and "g_per_L" exists.

In general products containing an active substance contents in "g_per_L" are liquids and products containing an active substance contents only in "percent" but not in "g_per_L" are solids.

For the calculation of "rate_g_per_ha" previously the active ingredient content in "percent" was used for entries with only a dosage (no rate). This has now been changed so that "g_per_L" is used if present and "percent" is used if there is no "g_per_L" entry.