### PR TITLE
Preserve culture_de = "allg." when resolving leaf cultures

### DIFF
--- a/R/resolve_cultures.R
+++ b/R/resolve_cultures.R
@@ -177,6 +177,9 @@ resolve_cultures <- function(dataset, srppp,
     }
   }
 
+  # save informationen culture_de is allg. = TRUE, else FALSE
+  dataset[["was_allg"]] <- dataset[[culture_column]] == "allg."
+
   if (resolve_culture_allg) {
     # Identify rows with "allg." in the culture column
     allg_rows <- dataset[[culture_column]] == "allg."
@@ -218,7 +221,16 @@ resolve_cultures <- function(dataset, srppp,
   names(join_spec) <- culture_column
 
   expanded_data <- dataset |>
-    left_join(culture_leaf_df, by = join_spec, relationship = "many-to-many")
+    left_join(culture_leaf_df, by = join_spec, relationship = "many-to-many") |>
+    mutate(
+      !!sym(culture_column) := if_else(
+        .data[["was_allg"]],
+        "allg.",
+        .data[[culture_column]]
+      )
+    ) |>
+    select(-all_of("was_allg"))
+
 
   return(expanded_data)
 }

--- a/R/resolve_cultures.R
+++ b/R/resolve_cultures.R
@@ -177,7 +177,10 @@ resolve_cultures <- function(dataset, srppp,
     }
   }
 
-  # save informationen culture_de is allg. = TRUE, else FALSE
+  # Save whether the original culture value is exactly "allg." (temporary helper column)
+  if ("was_allg" %in% names(dataset)) {
+    cli::cli_abort("{.var was_allg} is a reserved temporary column name used by {.fn resolve_cultures}; please rename it in {.arg dataset} before calling.")
+  }
   dataset[["was_allg"]] <- dataset[[culture_column]] == "allg."
 
   if (resolve_culture_allg) {

--- a/log/check.log
+++ b/log/check.log
@@ -1,79 +1,28 @@
-* using log directory ‘/home/f80868656/projects/srppp/srppp.Rcheck’
-* using R version 4.6.0 (2026-04-24)
+* using log directory ‘/home/f80835237/projects/srppp/srppp.Rcheck’
+* using R version 4.6.1 (2026-06-24)
 * using platform: x86_64-pc-linux-gnu
 * R was compiled by
     gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
     GNU Fortran (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
 * running under: Ubuntu 24.04.4 LTS
 * using session charset: UTF-8
-* current time: 2026-06-10 12:55:28 UTC
+* current time: 2026-07-21 12:49:26 UTC
 * using options ‘--no-tests --as-cran’
 * checking for file ‘srppp/DESCRIPTION’ ... OK
 * checking extension type ... Package
-* this is package ‘srppp’ version ‘2.0.5’
+* this is package ‘srppp’ version ‘2.0.6’
 * package encoding: UTF-8
 * checking CRAN incoming feasibility ... OK
 * checking package namespace information ... OK
-* checking package dependencies ... OK
-* checking if this is a source package ... OK
-* checking if there is a namespace ... OK
-* checking for executable files ... OK
-* checking for hidden files and directories ... OK
-* checking for portable file names ... OK
-* checking for sufficient/correct file permissions ... OK
-* checking whether package ‘srppp’ can be installed ... OK
-* checking installed package size ... OK
-* checking package directory ... OK
-* checking for future file timestamps ... OK
-* checking ‘build’ directory ... OK
-* checking DESCRIPTION meta-information ... OK
-* checking top-level files ... OK
-* checking for left-over files ... OK
-* checking index information ... OK
-* checking package subdirectories ... OK
-* checking code files for non-ASCII characters ... OK
-* checking R files for syntax errors ... OK
-* checking whether the package can be loaded ... OK
-* checking whether the package can be loaded with stated dependencies ... OK
-* checking whether the package can be unloaded cleanly ... OK
-* checking whether the namespace can be loaded with stated dependencies ... OK
-* checking whether the namespace can be unloaded cleanly ... OK
-* checking loading without being on the library search path ... OK
-* checking use of S3 registration ... OK
-* checking dependencies in R code ... OK
-* checking S3 generic/method consistency ... OK
-* checking replacement functions ... OK
-* checking foreign function calls ... OK
-* checking R code for possible problems ... OK
-* checking Rd files ... OK
-* checking Rd metadata ... OK
-* checking Rd line widths ... OK
-* checking Rd cross-references ... OK
-* checking for missing documentation entries ... OK
-* checking for code/documentation mismatches ... OK
-* checking Rd \usage sections ... OK
-* checking Rd contents ... OK
-* checking for unstated dependencies in examples ... OK
-* checking installed files from ‘inst/doc’ ... OK
-* checking files in ‘vignettes’ ... OK
-* checking examples ... OK
-* checking examples with --run-donttest ... [47s/67s] OK
-* checking for unstated dependencies in ‘tests’ ... OK
-* checking tests ... SKIPPED
-* checking for unstated dependencies in vignettes ... OK
-* checking package vignettes ... OK
-* checking re-building of vignette outputs ... [23s/26s] OK
-* checking PDF version of manual ... OK
-* checking HTML version of manual ... NOTE
-Skipping checking HTML validation: no command 'tidy' found.
-Please obtain a recent version of HTML Tidy by downloading a binary
-release or compiling the source code from <https://www.html-tidy.org/>.
-* checking for non-standard things in the check directory ... OK
-* checking for detritus in the temp directory ... OK
+* checking package dependencies ... ERROR
+Package required and available but unsuitable version: ‘DiagrammeR’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
 * DONE
 
-Status: 1 NOTE
+Status: 1 ERROR
 See
-  ‘/home/f80868656/projects/srppp/srppp.Rcheck/00check.log’
+  ‘/home/f80835237/projects/srppp/srppp.Rcheck/00check.log’
 for details.
 

--- a/log/test.log
+++ b/log/test.log
@@ -1,11 +1,13 @@
 ℹ Testing srppp
 ✔ | F W  S  OK | Context
-✔ |          7 | alternative_products [1.3s]
+✔ |          7 | alternative_products [1.2s]
 ✔ |         16 | resolve_cultures
-✔ |          6 | srppp_xml [13.7s]
-✔ |          9 | use_rates [13.7s]
+✔ |          6 | srppp_xml [15.3s]
+✔ |          9 | use_rates [13.0s]
 
 ══ Results ═════════════════════════════════════════════════════════════════════
-Duration: 28.9 s
+Duration: 29.7 s
 
 [ FAIL 0 | WARN 0 | SKIP 0 | PASS 38 ]
+
+🎸 Your tests rock 🎸


### PR DESCRIPTION
When using resolve_culture_allg = TRUE in resolve_cultures(), records with culture_de = "allg." are expanded to the corresponding leaf cultures based on application_area_de.

Previously, the value of culture_de was replaced by the resolved leaf culture. This has been changed. The original value "allg." is now kept by temporarily storing it and restoring it after the leaf cultures have been resolved.

See Example 5.